### PR TITLE
Various small fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ### Development versions after 0.9.1 release
 
 
+#### Build 2003141
+
+- Fixed color of main segment returned in JSON API during transition not being target color (closes #765)
+- Fixed arlsLock() being called after pixels set in E1.31 (closes #772)
+- Fixed HTTP API calls not having an effect if no segment selected (now applies to main segment)
+
 #### Build 2003121
 
 - Created changelog.md - make tracking changes to code easier

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -335,6 +335,8 @@ bool WS2812FX::setEffectConfig(uint8_t m, uint8_t s, uint8_t in, uint8_t p) {
   Segment& seg = _segments[getMainSegmentId()];
   uint8_t modePrev = seg.mode, speedPrev = seg.speed, intensityPrev = seg.intensity, palettePrev = seg.palette;
 
+  bool applied = false;
+  
   if (applyToAllSelected) {
     for (uint8_t i = 0; i < MAX_NUM_SEGMENTS; i++)
     {
@@ -344,9 +346,12 @@ bool WS2812FX::setEffectConfig(uint8_t m, uint8_t s, uint8_t in, uint8_t p) {
         _segments[i].intensity = in;
         _segments[i].palette = p;
         setMode(i, m);
+        applied = true;
       }
     }
-  } else {
+  } 
+  
+  if (!applyToAllSelected || !applied) {
     seg.speed = s;
     seg.intensity = in;
     seg.palette = p;
@@ -363,12 +368,17 @@ void WS2812FX::setColor(uint8_t slot, uint8_t r, uint8_t g, uint8_t b, uint8_t w
 
 void WS2812FX::setColor(uint8_t slot, uint32_t c) {
   if (slot >= NUM_COLORS) return;
+
+  bool applied = false;
+  
   if (applyToAllSelected) {
     for (uint8_t i = 0; i < MAX_NUM_SEGMENTS; i++)
     {
       if (_segments[i].isSelected()) _segments[i].colors[slot] = c;
     }
-  } else {
+  }
+
+  if (!applyToAllSelected || !applied) {
     _segments[getMainSegmentId()].colors[slot] = c;
   }
 }

--- a/wled00/wled00.ino
+++ b/wled00/wled00.ino
@@ -119,7 +119,7 @@
 #endif
 
 //version code in format yymmddb (b = daily build)
-#define VERSION 2003121
+#define VERSION 2003141
 
 char versionString[] = "0.9.1";
 

--- a/wled00/wled07_notify.ino
+++ b/wled00/wled07_notify.ino
@@ -121,6 +121,7 @@ void handleE131Packet(e131_packet_t* p, IPAddress clientIP){
     case DMX_MODE_SINGLE_RGB:
       if (uni != e131Universe) return;
       if (dmxChannels-DMXAddress+1 < 3) return;
+      arlsLock(realtimeTimeoutMs, REALTIME_MODE_E131);
       for (uint16_t i = 0; i < ledCount; i++)
         setRealtimePixel(i, p->property_values[DMXAddress+0], p->property_values[DMXAddress+1], p->property_values[DMXAddress+2], 0);
       break;
@@ -128,6 +129,7 @@ void handleE131Packet(e131_packet_t* p, IPAddress clientIP){
     case DMX_MODE_SINGLE_DRGB:
       if (uni != e131Universe) return;
       if (dmxChannels-DMXAddress+1 < 4) return;
+      arlsLock(realtimeTimeoutMs, REALTIME_MODE_E131);
       if (DMXOldDimmer != p->property_values[DMXAddress+0]) {
         DMXOldDimmer = p->property_values[DMXAddress+0];
         bri = p->property_values[DMXAddress+0];
@@ -166,6 +168,7 @@ void handleE131Packet(e131_packet_t* p, IPAddress clientIP){
       break;
 
     case DMX_MODE_MULTIPLE_RGB:
+      arlsLock(realtimeTimeoutMs, REALTIME_MODE_E131);
       if (previousUniverses == 0) {
         // first universe of this fixture
         possibleLEDsInCurrentUniverse = (dmxChannels - DMXAddress + 1) / 3;
@@ -187,6 +190,7 @@ void handleE131Packet(e131_packet_t* p, IPAddress clientIP){
       break;
 
     case DMX_MODE_MULTIPLE_DRGB:
+      arlsLock(realtimeTimeoutMs, REALTIME_MODE_E131);
       if (previousUniverses == 0) {
         // first universe of this fixture
         if (DMXOldDimmer != p->property_values[DMXAddress+0]) {
@@ -218,7 +222,6 @@ void handleE131Packet(e131_packet_t* p, IPAddress clientIP){
       break;
   }
 
-  arlsLock(realtimeTimeoutMs, REALTIME_MODE_E131);
   e131NewData = true;
 }
 


### PR DESCRIPTION
Fixed color of main segment returned in JSON API during transition not being target color
- Fixed arlsLock() being called after pixels set in E1.31, (closes #772)
- Fixed HTTP API calls not having an effect if no segment selected (now applies to main segment)