### PR TITLE
Hostname alphanumeric (#1048)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ### Development versions after 0.10.0 release
 
-#### Build 2007020
+#### Build 2007190
+
+-   Fixed hostname containing illegal characters (#1035)
 
 #### Build 2006251
 

--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -801,6 +801,16 @@ void WS2812FX::handle_palette(void)
   }
 }
 
+
+/*
+ * Gets a single color from the currently selected palette.
+ * @param i Palette Index (if mapping is true, the full palette will be SEGLEN long, if false, 255). Will wrap around automatically.
+ * @param mapping if true, LED position in segment is considered for color
+ * @param wrap FastLED palettes will usally wrap back to the start smoothly. Set false to get a hard edge
+ * @param mcol If the default palette 0 is selected, return the standard color 0, 1 or 2 instead. If >2, Party palette is used instead
+ * @param pbri Value to scale the brightness of the returned color by. Default is 255. (no scaling)
+ * @returns Single color from palette
+ */
 uint32_t WS2812FX::color_from_palette(uint16_t i, bool mapping, bool wrap, uint8_t mcol, uint8_t pbri)
 {
   if (SEGMENT.palette == 0 && mcol < 3) return SEGCOLOR(mcol); //WS2812FX default
@@ -812,6 +822,7 @@ uint32_t WS2812FX::color_from_palette(uint16_t i, bool mapping, bool wrap, uint8
   return  fastled_col.r*65536 +  fastled_col.g*256 +  fastled_col.b;
 }
 
+//@returns `true` if color, mode, speed, intensity and palette match
 bool WS2812FX::segmentsAreIdentical(Segment* a, Segment* b)
 {
   //if (a->start != b->start) return false;

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -8,7 +8,7 @@
  */
 
 // version code in format yymmddb (b = daily build)
-#define VERSION 2007020
+#define VERSION 2007190
 
 // ESP8266-01 (blue) got too little storage space to work with all features of WLED. To use it, you must use ESP8266 Arduino Core v2.4.2 and the setting 512K(No SPIFFS).
 


### PR DESCRIPTION
* Use string derived from serverDescription for wifi.hostname()

The code was sending illegal hostname strings to WiFi.hostname() (which is then submitted to DHCP and often times to DNS.)  A valid hostname contains only alphanumeric characters and hyphens (though it can't start with a hypen.)  This change simply alters the value passed to wifi.hostname() by replacing all non alphanum chars with hyphens while ensuring the first char is never a hyphen.  If the resulting hostname is empty, it uses the escapedMac value (which I'm assuming is initialized by the time this code executes.)

This change would result issue #1033

* replace string with char array
prefix wled
improve documentation

Co-authored-by: garyd9 <garyd9@hotmail.com>
Co-authored-by: Gary Dezern <gdezern@internal.youforgot.net>