### PR TITLE
Use arduino-esp32 2.0.2 for ESP32-S2 (#2452)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 ; default_envs = travis_esp8266, travis_esp32
 
 # Release binaries
-default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, esp32dev, esp32_eth
+default_envs = nodemcuv2, esp8266_2m, esp01_1m_full, esp32dev, esp32_eth, esp32s2_saola
 
 # Build everything
 ; default_envs = esp32dev, esp8285_4CH_MagicHome, esp8285_4CH_H801, codm-controller-0.6-rev2, codm-controller-0.6, esp32s2_saola, d1_mini_5CH_Shojo_PCB, d1_mini, sp501e, travis_esp8266, travis_esp32, nodemcuv2, esp32_eth, anavi_miracle_controller, esp07, esp01_1m_full, m5atom, h803wf, d1_mini_ota, heltec_wifi_kit_8, esp8285_5CH_H801, d1_mini_debug, wemos_shield_esp32, elekstube_ips
@@ -164,8 +164,7 @@ lib_compat_mode = strict
 lib_deps =
     fastled/FastLED @ 3.4.0
     IRremoteESP8266 @ 2.7.18
-    https://github.com/lorol/LITTLEFS.git
-    https://github.com/Aircoookie/ESPAsyncWebServer.git @ ~2.0.2
+    https://github.com/Aircoookie/ESPAsyncWebServer.git @ ~2.0.4
   #For use of the TTGO T-Display ESP32 Module with integrated TFT display uncomment the following line
     #TFT_eSPI
   #For use SSD1306 OLED display uncomment following
@@ -201,6 +200,7 @@ build_flags =
 
 lib_deps = 
   ${env.lib_deps}
+  https://github.com/lorol/LITTLEFS.git
   # ESPAsyncTCP @ 1.2.0
   ESPAsyncUDP
   makuna/NeoPixelBus @ 2.6.7 # 2.6.5/2.6.6 and newer do not compile on ESP core < 3.0.0
@@ -215,13 +215,13 @@ default_partitions = tools/WLED_ESP32_4MB_1MB_FS.csv
 
 lib_deps =
   ${env.lib_deps}
+  https://github.com/lorol/LITTLEFS.git
   makuna/NeoPixelBus @ 2.6.7
   https://github.com/pbolduc/AsyncTCP.git @ 1.2.0
 
 [esp32s2]
 build_flags = -g
   -DARDUINO_ARCH_ESP32
-  -DCONFIG_LITTLEFS_FOR_IDF_3_2
   -DARDUINO_ARCH_ESP32S2
   -DCONFIG_IDF_TARGET_ESP32S2
   -D CONFIG_ASYNC_TCP_USE_WDT=0
@@ -317,14 +317,13 @@ lib_deps = ${esp32.lib_deps}
 board_build.partitions = ${esp32.default_partitions}
 
 [env:esp32s2_saola]
-board = esp32dev
-board_build.mcu = esp32s2
-platform = espressif32
+board = esp32-s2-saola-1
+platform = https://github.com/tasmota/platform-espressif32/releases/download/v3.4.1/Tasmota-platform-espressif32.zip
 platform_packages =
-    toolchain-xtensa32s2
-    framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#2.0.0-alpha1
+    framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#2.0.2
 framework = arduino
 board_build.partitions = tools/WLED_ESP32_4MB_1MB_FS.csv
+board_build.flash_mode = qio
 upload_speed = 460800
 build_unflags = ${common.build_unflags}
 lib_deps = ${esp32s2.lib_deps}

--- a/wled00/file.cpp
+++ b/wled00/file.cpp
@@ -5,7 +5,7 @@
  */
 
 #ifdef ARDUINO_ARCH_ESP32 //FS info bare IDF function until FS wrapper is available for ESP32
-#if WLED_FS != LITTLEFS
+#if WLED_FS != LITTLEFS && ESP_IDF_VERSION_MAJOR < 4
   #include "esp_spiffs.h"
 #endif
 #endif
@@ -359,9 +359,9 @@ bool readObjectFromFile(const char* file, const char* key, JsonDocument* dest)
 
 void updateFSInfo() {
   #ifdef ARDUINO_ARCH_ESP32
-    #if WLED_FS == LITTLEFS
-    fsBytesTotal = LITTLEFS.totalBytes();
-    fsBytesUsed = LITTLEFS.usedBytes();
+    #if WLED_FS == LITTLEFS || ESP_IDF_VERSION_MAJOR >= 4
+    fsBytesTotal = WLED_FS.totalBytes();
+    fsBytesUsed = WLED_FS.usedBytes();
     #else
     esp_spiffs_info(nullptr, &fsBytesTotal, &fsBytesUsed);
     #endif

--- a/wled00/wled.h
+++ b/wled00/wled.h
@@ -70,10 +70,14 @@
   #include <ESPmDNS.h>
   #include <AsyncTCP.h>
   //#include "SPIFFS.h"
-  #ifndef CONFIG_LITTLEFS_FOR_IDF_3_2
-    #define CONFIG_LITTLEFS_FOR_IDF_3_2
+  #if ESP_IDF_VERSION_MAJOR < 4
+    #ifndef CONFIG_LITTLEFS_FOR_IDF_3_2
+      #define CONFIG_LITTLEFS_FOR_IDF_3_2
+    #endif
+    #include <LITTLEFS.h>
+  #else
+    #include <LittleFS.h>
   #endif
-  #include <LITTLEFS.h>
 #endif
 
 #include "src/dependencies/network/Network.h"
@@ -172,7 +176,11 @@ using PSRAMDynamicJsonDocument = BasicJsonDocument<PSRAM_Allocator>;
 #ifdef ESP8266
   #define WLED_FS LittleFS
 #else
-  #define WLED_FS LITTLEFS
+  #if ESP_IDF_VERSION_MAJOR < 4
+    #define WLED_FS LITTLEFS
+  #else
+    #define WLED_FS LittleFS
+  #endif
 #endif
 
 // GLOBAL VARIABLES


### PR DESCRIPTION
* Use arduino-esp32 2.0.2 for ESP32-S2

LittleFS is merged into it.

* Fix filesystem error for ESP32-S2

Use platform of tasmota until upstream released it and
use board_build.flash_mode = qio

* Fix empty disk usage

* Add esp32s2_saola to default_envs

* Remove lorol LITTLEFS for esp32dev, too

* Revert "Remove lorol LITTLEFS for esp32dev, too"

This reverts commit 3586d5eef7affa3390bd057232600f6189145706.